### PR TITLE
Function.bind prototype polyfill

### DIFF
--- a/public/javascripts/phantomjs-hack.js
+++ b/public/javascripts/phantomjs-hack.js
@@ -1,0 +1,30 @@
+/**
+ * Created by toby on 26/01/16.
+ */
+
+// Pollyfill fix as phantomjs does not implement Function.prototype.bind
+// See https://github.com/ariya/phantomjs/issues/11281
+if (!Function.prototype.bind) {
+  Function.prototype.bind = function (oThis) {
+    if (typeof this !== "function") {
+      // closest thing possible to the ECMAScript 5
+      // internal IsCallable function
+      throw new TypeError("Function.prototype.bind - what is trying to be bound is not callable");
+    }
+
+    var aArgs = Array.prototype.slice.call(arguments, 1),
+      fToBind = this,
+      fNOP = function () {},
+      fBound = function () {
+        return fToBind.apply(this instanceof fNOP && oThis
+            ? this
+            : oThis,
+          aArgs.concat(Array.prototype.slice.call(arguments)));
+      };
+
+    fNOP.prototype = this.prototype;
+    fBound.prototype = new fNOP();
+
+    return fBound;
+  };
+}

--- a/views/report_layout.jade
+++ b/views/report_layout.jade
@@ -22,7 +22,7 @@ html
          link(rel='stylesheet', href='/stylesheets/style.css')
          link(rel='stylesheet', href='/stylesheets/flexStyleIndicator.css')
 
-
+         script(src="/javascripts/phantomjs-hack.js")
 
          script.
             var config_obj = !{JSON.stringify(config_obj)};


### PR DESCRIPTION
Included via report_layout.jade - I'm assuming this will cover all cases in which phantomjs is used?
